### PR TITLE
add Importing command from text

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,77 +1,78 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
-	<groupId>edu.kis.powp</groupId>
-	<artifactId>jobs2d</artifactId>
-	<version>0.0.3-SNAPSHOT</version>
-	<name>Visual2Djobs</name>
-	<description>POWP software for devices operating on 2d plane</description>
-  
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.0</version>
-				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
-					<encoding>UTF-8</encoding>
-					<showDeprecation>true</showDeprecation>
-				</configuration>
-			</plugin>
-		</plugins>
-	</build>
-	
-	<dependencies>	
-		<dependency>
-	        <groupId>edu.kis.powp.jobs2d</groupId>
-	        <artifactId>jobs2dmagic</artifactId>
-	        <version>1.0.0</version>
-	        <scope>system</scope>
-	        <systemPath>${project.basedir}/lib/Jobs2dMagic.jar</systemPath>
-	    </dependency>
-	    <dependency>
-	        <groupId>edu.kis.legacy</groupId>
-	        <artifactId>drawer</artifactId>
-	        <version>1.0.0</version>
-	        <scope>system</scope>
-	        <systemPath>${project.basedir}/lib/Drawer.jar</systemPath>
-	    </dependency>
-		<dependency>
-	        <groupId>edu.kis.powp</groupId>
-	        <artifactId>appbase</artifactId>
-	        <version>1.0.0</version>
-	        <scope>system</scope>
-	        <systemPath>${project.basedir}/lib/PowpAppBase.jar</systemPath>
-	    </dependency>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>edu.kis.powp</groupId>
+    <artifactId>jobs2d</artifactId>
+    <version>0.0.3-SNAPSHOT</version>
+    <name>Visual2Djobs</name>
+    <description>POWP software for devices operating on 2d plane</description>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.0</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                    <encoding>UTF-8</encoding>
+                    <showDeprecation>true</showDeprecation>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>edu.kis.powp.jobs2d</groupId>
+            <artifactId>jobs2dmagic</artifactId>
+            <version>1.0.0</version>
+            <scope>system</scope>
+            <systemPath>${project.basedir}/lib/Jobs2dMagic.jar</systemPath>
+        </dependency>
+        <dependency>
+            <groupId>edu.kis.legacy</groupId>
+            <artifactId>drawer</artifactId>
+            <version>1.0.0</version>
+            <scope>system</scope>
+            <systemPath>${project.basedir}/lib/Drawer.jar</systemPath>
+        </dependency>
+        <dependency>
+            <groupId>edu.kis.powp</groupId>
+            <artifactId>appbase</artifactId>
+            <version>1.0.0</version>
+            <scope>system</scope>
+            <systemPath>${project.basedir}/lib/PowpAppBase.jar</systemPath>
+        </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.13.2</version>
             <scope>test</scope>
         </dependency>
-		<dependency>
-			<groupId>org.junit.jupiter</groupId>
-			<artifactId>junit-jupiter</artifactId>
-			<version>RELEASE</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>com.fasterxml.jackson.core</groupId>
-			<artifactId>jackson-databind</artifactId>
-			<version>2.13.0</version>
-		</dependency>
-		<dependency>
-			<groupId>com.fasterxml.jackson.dataformat</groupId>
-			<artifactId>jackson-dataformat-xml</artifactId>
-			<version>2.13.0</version>
-		</dependency>
-		<dependency>
-			<groupId>com.fasterxml.jackson.dataformat</groupId>
-			<artifactId>jackson-dataformat-csv</artifactId>
-			<version>2.13.0</version>
-		</dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>RELEASE</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.13.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-xml</artifactId>
+            <version>2.13.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-csv</artifactId>
+            <version>2.13.0</version>
+        </dependency>
 
-	</dependencies>
-	
+    </dependencies>
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,22 @@
 			<version>RELEASE</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-databind</artifactId>
+			<version>2.13.0</version>
+		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.dataformat</groupId>
+			<artifactId>jackson-dataformat-xml</artifactId>
+			<version>2.13.0</version>
+		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.dataformat</groupId>
+			<artifactId>jackson-dataformat-csv</artifactId>
+			<version>2.13.0</version>
+		</dependency>
+
 	</dependencies>
 	
 </project>

--- a/src/main/java/edu/kis/powp/jobs2d/command/gui/CommandManagerWindow.java
+++ b/src/main/java/edu/kis/powp/jobs2d/command/gui/CommandManagerWindow.java
@@ -1,22 +1,15 @@
 package edu.kis.powp.jobs2d.command.gui;
 
-import java.awt.*;
-import java.awt.event.ActionEvent;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.stream.Stream;
-
-import javax.swing.*;
-
 import edu.kis.powp.appbase.gui.WindowComponent;
-import edu.kis.powp.jobs2d.command.CompoundCommand;
 import edu.kis.powp.jobs2d.command.DriverCommand;
 import edu.kis.powp.jobs2d.command.manager.DriverCommandManager;
 import edu.kis.powp.jobs2d.command.parser.CommandParserFactory;
-import edu.kis.powp.jobs2d.command.parser.CommandParserStrategy;
-import edu.kis.powp.jobs2d.command.parser.jackson.JacksonParserFactory;
 import edu.kis.powp.observer.Subscriber;
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.event.ActionEvent;
+import java.util.List;
 
 public class CommandManagerWindow extends JFrame implements WindowComponent {
 

--- a/src/main/java/edu/kis/powp/jobs2d/command/gui/CommandManagerWindow.java
+++ b/src/main/java/edu/kis/powp/jobs2d/command/gui/CommandManagerWindow.java
@@ -99,9 +99,11 @@ public class CommandManagerWindow extends JFrame implements WindowComponent {
         btnSetCommand.addActionListener((ActionEvent e) -> {
             String chosenCommand = (String) selectType.getSelectedItem();
             String newCommandName = newCommandNameField.getText();
+            String rawCommand = userInputField.getText();
             try {
-                List<DriverCommand> parsedCommand = parserFactory.getParser(chosenCommand).parse(userInputField.getText());
-                commandManager.setCurrentCommand(parsedCommand, newCommandName);
+                DriverCommand parsedCommand = parserFactory.getParser(chosenCommand)
+                        .parse(rawCommand, newCommandName);
+                commandManager.setCurrentCommand(parsedCommand);
             } catch (Exception ex) {
                 JOptionPane.showMessageDialog(this, ex);
             }

--- a/src/main/java/edu/kis/powp/jobs2d/command/gui/CommandManagerWindow.java
+++ b/src/main/java/edu/kis/powp/jobs2d/command/gui/CommandManagerWindow.java
@@ -20,155 +20,152 @@ import edu.kis.powp.observer.Subscriber;
 
 public class CommandManagerWindow extends JFrame implements WindowComponent {
 
-	private DriverCommandManager commandManager;
+    private DriverCommandManager commandManager;
 
-	private JTextArea currentCommandField;
-	private JTextArea userInputField;
-	private JTextField newCommandNameField;
+    private JTextArea currentCommandField;
+    private JTextArea userInputField;
+    private JTextField newCommandNameField;
 
-	private String observerListString;
-	private JTextArea observerListField;
+    private String observerListString;
+    private JTextArea observerListField;
 
-	private static final long serialVersionUID = 9204679248304669948L;
+    private static final long serialVersionUID = 9204679248304669948L;
 
-	public CommandManagerWindow(DriverCommandManager commandManager, CommandParserFactory parserFactory) {
-		this.setTitle("Command Manager");
-		this.setSize(400, 400);
-		Container content = this.getContentPane();
-		content.setLayout(new GridBagLayout());
+    public CommandManagerWindow(DriverCommandManager commandManager, CommandParserFactory parserFactory) {
+        this.setTitle("Command Manager");
+        this.setSize(400, 400);
+        Container content = this.getContentPane();
+        content.setLayout(new GridBagLayout());
 
-		this.commandManager = commandManager;
+        this.commandManager = commandManager;
 
-		GridBagConstraints c = new GridBagConstraints();
+        GridBagConstraints c = new GridBagConstraints();
 
-		observerListField = new JTextArea("");
-		observerListField.setEditable(false);
-		c.fill = GridBagConstraints.BOTH;
-		c.weightx = 1;
-		c.gridx = 0;
-		c.weighty = 0;
-		content.add(observerListField, c);
-		updateObserverListField();
+        observerListField = new JTextArea("");
+        observerListField.setEditable(false);
+        c.fill = GridBagConstraints.BOTH;
+        c.weightx = 1;
+        c.gridx = 0;
+        c.weighty = 0;
+        content.add(observerListField, c);
+        updateObserverListField();
 
-		currentCommandField = new JTextArea("");
-		currentCommandField.setEditable(false);
-		c.fill = GridBagConstraints.BOTH;
-		c.weightx = 1;
-		c.gridx = 0;
-		c.weighty = 0;
-		content.add(currentCommandField, c);
-		updateCurrentCommandField();
+        currentCommandField = new JTextArea("");
+        currentCommandField.setEditable(false);
+        c.fill = GridBagConstraints.BOTH;
+        c.weightx = 1;
+        c.gridx = 0;
+        c.weighty = 0;
+        content.add(currentCommandField, c);
+        updateCurrentCommandField();
 
-		JLabel newCommandNameLabel = new JLabel("New Command name:");
-		newCommandNameField = new JTextField();
+        JLabel newCommandNameLabel = new JLabel("New Command name:");
+        newCommandNameField = new JTextField();
 
-		JPanel namePanel = new JPanel(new GridBagLayout());
-		GridBagConstraints namePanelConstraints = new GridBagConstraints();
-		namePanelConstraints.fill = GridBagConstraints.BOTH;
-		namePanelConstraints.weightx = 0.5;
-		namePanelConstraints.gridx = 0;
-		namePanelConstraints.gridy = 0;
-		namePanel.add(newCommandNameLabel, namePanelConstraints);
+        JPanel namePanel = new JPanel(new GridBagLayout());
+        GridBagConstraints namePanelConstraints = new GridBagConstraints();
+        namePanelConstraints.fill = GridBagConstraints.BOTH;
+        namePanelConstraints.weightx = 0.5;
+        namePanelConstraints.gridx = 0;
+        namePanelConstraints.gridy = 0;
+        namePanel.add(newCommandNameLabel, namePanelConstraints);
 
-		namePanelConstraints.gridx = 1;
-		namePanel.add(newCommandNameField, namePanelConstraints);
+        namePanelConstraints.gridx = 1;
+        namePanel.add(newCommandNameField, namePanelConstraints);
 
-		c.fill = GridBagConstraints.BOTH;
-		c.weightx = 1;
-		c.gridx = 0;
-		c.weighty = 0;
-		content.add(namePanel, c);
+        c.fill = GridBagConstraints.BOTH;
+        c.weightx = 1;
+        c.gridx = 0;
+        c.weighty = 0;
+        content.add(namePanel, c);
 
-		userInputField = new JTextArea();
-		userInputField.setBorder(
-				BorderFactory.createLineBorder(Color.BLACK, 1)
-		);
-		userInputField.setMinimumSize(new Dimension(200, 200));
-		c.fill = GridBagConstraints.BOTH;
-		c.weightx = 1;
-		c.gridx = 0;
-		c.weighty = 1;
-		content.add(userInputField, c);
+        userInputField = new JTextArea();
+        userInputField.setBorder(BorderFactory.createLineBorder(Color.BLACK, 1));
+        userInputField.setMinimumSize(new Dimension(200, 200));
+        c.fill = GridBagConstraints.BOTH;
+        c.weightx = 1;
+        c.gridx = 0;
+        c.weighty = 1;
+        content.add(userInputField, c);
 
-		JPanel panel = new JPanel(new GridBagLayout());
-		GridBagConstraints panelConstraints = new GridBagConstraints();
-		panelConstraints.fill = GridBagConstraints.BOTH;
-		panelConstraints.weightx = 0.5;
-		panelConstraints.gridx = 0;
-		panelConstraints.gridy = 0;
+        JPanel panel = new JPanel(new GridBagLayout());
+        GridBagConstraints panelConstraints = new GridBagConstraints();
+        panelConstraints.fill = GridBagConstraints.BOTH;
+        panelConstraints.weightx = 0.5;
+        panelConstraints.gridx = 0;
+        panelConstraints.gridy = 0;
 
-		JButton btnSetCommand = new JButton("Set command");
-		panel.add(btnSetCommand, panelConstraints);
+        JButton btnSetCommand = new JButton("Set command");
+        panel.add(btnSetCommand, panelConstraints);
 
-		String[] availableCommands = parserFactory.getAvailableParsers().toArray(new String[0]);
-		JComboBox<String> selectType = new JComboBox<>(availableCommands);
-		panelConstraints.gridx = 1;
-		panel.add(selectType, panelConstraints);
+        String[] availableCommands = parserFactory.getAvailableParsers().toArray(new String[0]);
+        JComboBox<String> selectType = new JComboBox<>(availableCommands);
+        panelConstraints.gridx = 1;
+        panel.add(selectType, panelConstraints);
 
-		btnSetCommand.addActionListener((ActionEvent e) -> {
-			String chosenCommand = (String) selectType.getSelectedItem();
-			String newCommandName = newCommandNameField.getText();
-			try {
-				List<DriverCommand>  parsedCommand = parserFactory.getParser(chosenCommand).parse(userInputField.getText());
-				commandManager.setCurrentCommand(parsedCommand, newCommandName);
-			} catch (Exception ex) {
-				JOptionPane.showMessageDialog(this, ex);
-			}
-			updateCurrentCommandField();
-		});
+        btnSetCommand.addActionListener((ActionEvent e) -> {
+            String chosenCommand = (String) selectType.getSelectedItem();
+            String newCommandName = newCommandNameField.getText();
+            try {
+                List<DriverCommand> parsedCommand = parserFactory.getParser(chosenCommand).parse(userInputField.getText());
+                commandManager.setCurrentCommand(parsedCommand, newCommandName);
+            } catch (Exception ex) {
+                JOptionPane.showMessageDialog(this, ex);
+            }
+            updateCurrentCommandField();
+        });
 
-		c.fill = GridBagConstraints.BOTH;
-		c.weightx = 1;
-		c.gridx = 0;
-		c.weighty = 0;
-		content.add(panel, c);
+        c.fill = GridBagConstraints.BOTH;
+        c.weightx = 1;
+        c.gridx = 0;
+        c.weighty = 0;
+        content.add(panel, c);
 
-		JButton btnClearCommand = new JButton("Clear command");
-		btnClearCommand.addActionListener((ActionEvent e) -> this.clearCommand());
-		c.fill = GridBagConstraints.BOTH;
-		c.weightx = 1;
-		c.gridx = 0;
-		c.weighty = 0;
-		content.add(btnClearCommand, c);
+        JButton btnClearCommand = new JButton("Clear command");
+        btnClearCommand.addActionListener((ActionEvent e) -> this.clearCommand());
+        c.fill = GridBagConstraints.BOTH;
+        c.weightx = 1;
+        c.gridx = 0;
+        c.weighty = 0;
+        content.add(btnClearCommand, c);
 
-		JButton btnClearObservers = new JButton("Delete observers");
-		btnClearObservers.addActionListener((ActionEvent e) -> this.deleteObservers());
-		c.fill = GridBagConstraints.BOTH;
-		c.weightx = 1;
-		c.gridx = 0;
-		c.weighty = 0;
-		content.add(btnClearObservers, c);
-	}
+        JButton btnClearObservers = new JButton("Delete observers");
+        btnClearObservers.addActionListener((ActionEvent e) -> this.deleteObservers());
+        c.fill = GridBagConstraints.BOTH;
+        c.weightx = 1;
+        c.gridx = 0;
+        c.weighty = 0;
+        content.add(btnClearObservers, c);
+    }
 
-	private void clearCommand() {
-		commandManager.clearCurrentCommand();
-		updateCurrentCommandField();
-	}
+    private void clearCommand() {
+        commandManager.clearCurrentCommand();
+        updateCurrentCommandField();
+    }
 
-	public void updateCurrentCommandField() {
-		currentCommandField.setText(commandManager.getCurrentCommandString());
-	}
+    public void updateCurrentCommandField() {
+        currentCommandField.setText(commandManager.getCurrentCommandString());
+    }
 
-	public void deleteObservers() {
-		commandManager.getChangePublisher().clearObservers();
-		this.updateObserverListField();
-	}
+    public void deleteObservers() {
+        commandManager.getChangePublisher().clearObservers();
+        this.updateObserverListField();
+    }
 
-	private void updateObserverListField() {
-		observerListString = "";
-		List<Subscriber> commandChangeSubscribers = commandManager.getChangePublisher().getSubscribers();
-		for (Subscriber observer : commandChangeSubscribers) {
-			observerListString += observer.toString() + System.lineSeparator();
-		}
-		if (commandChangeSubscribers.isEmpty())
-			observerListString = "No observers loaded";
+    private void updateObserverListField() {
+        observerListString = "";
+        List<Subscriber> commandChangeSubscribers = commandManager.getChangePublisher().getSubscribers();
+        for (Subscriber observer : commandChangeSubscribers) {
+            observerListString += observer.toString() + System.lineSeparator();
+        }
+        if (commandChangeSubscribers.isEmpty()) observerListString = "No observers loaded";
 
-		observerListField.setText(observerListString);
-	}
+        observerListField.setText(observerListString);
+    }
 
-	@Override
-	public void HideIfVisibleAndShowIfHidden() {
-		updateObserverListField();
-		this.setVisible(!this.isVisible());
-	}
+    @Override
+    public void HideIfVisibleAndShowIfHidden() {
+        updateObserverListField();
+        this.setVisible(!this.isVisible());
+    }
 }

--- a/src/main/java/edu/kis/powp/jobs2d/command/gui/CommandManagerWindow.java
+++ b/src/main/java/edu/kis/powp/jobs2d/command/gui/CommandManagerWindow.java
@@ -1,108 +1,174 @@
 package edu.kis.powp.jobs2d.command.gui;
 
-import java.awt.Container;
-import java.awt.GridBagConstraints;
-import java.awt.GridBagLayout;
+import java.awt.*;
 import java.awt.event.ActionEvent;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Stream;
 
-import javax.swing.JButton;
-import javax.swing.JFrame;
-import javax.swing.JTextArea;
+import javax.swing.*;
 
 import edu.kis.powp.appbase.gui.WindowComponent;
+import edu.kis.powp.jobs2d.command.CompoundCommand;
+import edu.kis.powp.jobs2d.command.DriverCommand;
 import edu.kis.powp.jobs2d.command.manager.DriverCommandManager;
+import edu.kis.powp.jobs2d.command.parser.CommandParserFactory;
+import edu.kis.powp.jobs2d.command.parser.CommandParserStrategy;
+import edu.kis.powp.jobs2d.command.parser.jackson.JacksonParserFactory;
 import edu.kis.powp.observer.Subscriber;
 
 public class CommandManagerWindow extends JFrame implements WindowComponent {
 
-    private DriverCommandManager commandManager;
+	private DriverCommandManager commandManager;
 
-    private JTextArea currentCommandField;
+	private JTextArea currentCommandField;
+	private JTextArea userInputField;
+	private JTextField newCommandNameField;
 
-    private String observerListString;
-    private JTextArea observerListField;
+	private String observerListString;
+	private JTextArea observerListField;
 
-    /**
-     * 
-     */
-    private static final long serialVersionUID = 9204679248304669948L;
+	private static final long serialVersionUID = 9204679248304669948L;
 
-    public CommandManagerWindow(DriverCommandManager commandManager) {
-        this.setTitle("Command Manager");
-        this.setSize(400, 400);
-        Container content = this.getContentPane();
-        content.setLayout(new GridBagLayout());
+	public CommandManagerWindow(DriverCommandManager commandManager, CommandParserFactory parserFactory) {
+		this.setTitle("Command Manager");
+		this.setSize(400, 400);
+		Container content = this.getContentPane();
+		content.setLayout(new GridBagLayout());
 
-        this.commandManager = commandManager;
+		this.commandManager = commandManager;
 
-        GridBagConstraints c = new GridBagConstraints();
+		GridBagConstraints c = new GridBagConstraints();
 
-        observerListField = new JTextArea("");
-        observerListField.setEditable(false);
-        c.fill = GridBagConstraints.BOTH;
-        c.weightx = 1;
-        c.gridx = 0;
-        c.weighty = 1;
-        content.add(observerListField, c);
-        updateObserverListField();
+		observerListField = new JTextArea("");
+		observerListField.setEditable(false);
+		c.fill = GridBagConstraints.BOTH;
+		c.weightx = 1;
+		c.gridx = 0;
+		c.weighty = 0;
+		content.add(observerListField, c);
+		updateObserverListField();
 
-        currentCommandField = new JTextArea("");
-        currentCommandField.setEditable(false);
-        c.fill = GridBagConstraints.BOTH;
-        c.weightx = 1;
-        c.gridx = 0;
-        c.weighty = 1;
-        content.add(currentCommandField, c);
-        updateCurrentCommandField();
+		currentCommandField = new JTextArea("");
+		currentCommandField.setEditable(false);
+		c.fill = GridBagConstraints.BOTH;
+		c.weightx = 1;
+		c.gridx = 0;
+		c.weighty = 0;
+		content.add(currentCommandField, c);
+		updateCurrentCommandField();
 
-        JButton btnClearCommand = new JButton("Clear command");
-        btnClearCommand.addActionListener((ActionEvent e) -> this.clearCommand());
-        c.fill = GridBagConstraints.BOTH;
-        c.weightx = 1;
-        c.gridx = 0;
-        c.weighty = 1;
-        content.add(btnClearCommand, c);
+		JLabel newCommandNameLabel = new JLabel("New Command name:");
+		newCommandNameField = new JTextField();
 
-        JButton btnClearObservers = new JButton("Delete observers");
-        btnClearObservers.addActionListener((ActionEvent e) -> this.deleteObservers());
-        c.fill = GridBagConstraints.BOTH;
-        c.weightx = 1;
-        c.gridx = 0;
-        c.weighty = 1;
-        content.add(btnClearObservers, c);
-    }
+		JPanel namePanel = new JPanel(new GridBagLayout());
+		GridBagConstraints namePanelConstraints = new GridBagConstraints();
+		namePanelConstraints.fill = GridBagConstraints.BOTH;
+		namePanelConstraints.weightx = 0.5;
+		namePanelConstraints.gridx = 0;
+		namePanelConstraints.gridy = 0;
+		namePanel.add(newCommandNameLabel, namePanelConstraints);
 
-    private void clearCommand() {
-        commandManager.clearCurrentCommand();
-        updateCurrentCommandField();
-    }
+		namePanelConstraints.gridx = 1;
+		namePanel.add(newCommandNameField, namePanelConstraints);
 
-    public void updateCurrentCommandField() {
-        currentCommandField.setText(commandManager.getCurrentCommandString());
-    }
+		c.fill = GridBagConstraints.BOTH;
+		c.weightx = 1;
+		c.gridx = 0;
+		c.weighty = 0;
+		content.add(namePanel, c);
 
-    public void deleteObservers() {
-        commandManager.getChangePublisher().clearObservers();
-        this.updateObserverListField();
-    }
+		userInputField = new JTextArea();
+		userInputField.setBorder(
+				BorderFactory.createLineBorder(Color.BLACK, 1)
+		);
+		userInputField.setMinimumSize(new Dimension(200, 200));
+		c.fill = GridBagConstraints.BOTH;
+		c.weightx = 1;
+		c.gridx = 0;
+		c.weighty = 1;
+		content.add(userInputField, c);
 
-    private void updateObserverListField() {
-        observerListString = "";
-        List<Subscriber> commandChangeSubscribers = commandManager.getChangePublisher().getSubscribers();
-        for (Subscriber observer : commandChangeSubscribers) {
-            observerListString += observer.toString() + System.lineSeparator();
-        }
-        if (commandChangeSubscribers.isEmpty())
-            observerListString = "No observers loaded";
+		JPanel panel = new JPanel(new GridBagLayout());
+		GridBagConstraints panelConstraints = new GridBagConstraints();
+		panelConstraints.fill = GridBagConstraints.BOTH;
+		panelConstraints.weightx = 0.5;
+		panelConstraints.gridx = 0;
+		panelConstraints.gridy = 0;
 
-        observerListField.setText(observerListString);
-    }
+		JButton btnSetCommand = new JButton("Set command");
+		panel.add(btnSetCommand, panelConstraints);
 
-    @Override
-    public void HideIfVisibleAndShowIfHidden() {
-        updateObserverListField();
-        this.setVisible(!this.isVisible());
-    }
+		String[] availableCommands = parserFactory.getAvailableParsers().toArray(new String[0]);
+		JComboBox<String> selectType = new JComboBox<>(availableCommands);
+		panelConstraints.gridx = 1;
+		panel.add(selectType, panelConstraints);
 
+		btnSetCommand.addActionListener((ActionEvent e) -> {
+			String chosenCommand = (String) selectType.getSelectedItem();
+			String newCommandName = newCommandNameField.getText();
+			try {
+				List<DriverCommand>  parsedCommand = parserFactory.getParser(chosenCommand).parse(userInputField.getText());
+				commandManager.setCurrentCommand(parsedCommand, newCommandName);
+			} catch (Exception ex) {
+				JOptionPane.showMessageDialog(this, ex);
+			}
+			updateCurrentCommandField();
+		});
+
+		c.fill = GridBagConstraints.BOTH;
+		c.weightx = 1;
+		c.gridx = 0;
+		c.weighty = 0;
+		content.add(panel, c);
+
+		JButton btnClearCommand = new JButton("Clear command");
+		btnClearCommand.addActionListener((ActionEvent e) -> this.clearCommand());
+		c.fill = GridBagConstraints.BOTH;
+		c.weightx = 1;
+		c.gridx = 0;
+		c.weighty = 0;
+		content.add(btnClearCommand, c);
+
+		JButton btnClearObservers = new JButton("Delete observers");
+		btnClearObservers.addActionListener((ActionEvent e) -> this.deleteObservers());
+		c.fill = GridBagConstraints.BOTH;
+		c.weightx = 1;
+		c.gridx = 0;
+		c.weighty = 0;
+		content.add(btnClearObservers, c);
+	}
+
+	private void clearCommand() {
+		commandManager.clearCurrentCommand();
+		updateCurrentCommandField();
+	}
+
+	public void updateCurrentCommandField() {
+		currentCommandField.setText(commandManager.getCurrentCommandString());
+	}
+
+	public void deleteObservers() {
+		commandManager.getChangePublisher().clearObservers();
+		this.updateObserverListField();
+	}
+
+	private void updateObserverListField() {
+		observerListString = "";
+		List<Subscriber> commandChangeSubscribers = commandManager.getChangePublisher().getSubscribers();
+		for (Subscriber observer : commandChangeSubscribers) {
+			observerListString += observer.toString() + System.lineSeparator();
+		}
+		if (commandChangeSubscribers.isEmpty())
+			observerListString = "No observers loaded";
+
+		observerListField.setText(observerListString);
+	}
+
+	@Override
+	public void HideIfVisibleAndShowIfHidden() {
+		updateObserverListField();
+		this.setVisible(!this.isVisible());
+	}
 }

--- a/src/main/java/edu/kis/powp/jobs2d/command/parser/CommandParserFactory.java
+++ b/src/main/java/edu/kis/powp/jobs2d/command/parser/CommandParserFactory.java
@@ -1,0 +1,9 @@
+package edu.kis.powp.jobs2d.command.parser;
+
+import java.util.Collection;
+
+public interface CommandParserFactory {
+
+	Collection<String> getAvailableParsers();
+	CommandParserStrategy getParser(String parserName);
+}

--- a/src/main/java/edu/kis/powp/jobs2d/command/parser/CommandParserFactory.java
+++ b/src/main/java/edu/kis/powp/jobs2d/command/parser/CommandParserFactory.java
@@ -4,6 +4,7 @@ import java.util.Collection;
 
 public interface CommandParserFactory {
 
-	Collection<String> getAvailableParsers();
-	CommandParserStrategy getParser(String parserName);
+    Collection<String> getAvailableParsers();
+
+    CommandParserStrategy getParser(String parserName);
 }

--- a/src/main/java/edu/kis/powp/jobs2d/command/parser/CommandParserStrategy.java
+++ b/src/main/java/edu/kis/powp/jobs2d/command/parser/CommandParserStrategy.java
@@ -8,6 +8,7 @@ import java.util.List;
 
 public interface CommandParserStrategy {
 
-	String getStrategyName();
-	List<DriverCommand> parse(String rawCommand) throws IOException;
+    String getStrategyName();
+
+    List<DriverCommand> parse(String rawCommand) throws IOException;
 }

--- a/src/main/java/edu/kis/powp/jobs2d/command/parser/CommandParserStrategy.java
+++ b/src/main/java/edu/kis/powp/jobs2d/command/parser/CommandParserStrategy.java
@@ -1,0 +1,13 @@
+package edu.kis.powp.jobs2d.command.parser;
+
+import edu.kis.powp.jobs2d.command.CompoundCommand;
+import edu.kis.powp.jobs2d.command.DriverCommand;
+
+import java.io.IOException;
+import java.util.List;
+
+public interface CommandParserStrategy {
+
+	String getStrategyName();
+	List<DriverCommand> parse(String rawCommand) throws IOException;
+}

--- a/src/main/java/edu/kis/powp/jobs2d/command/parser/CommandParserStrategy.java
+++ b/src/main/java/edu/kis/powp/jobs2d/command/parser/CommandParserStrategy.java
@@ -1,14 +1,12 @@
 package edu.kis.powp.jobs2d.command.parser;
 
-import edu.kis.powp.jobs2d.command.CompoundCommand;
 import edu.kis.powp.jobs2d.command.DriverCommand;
 
 import java.io.IOException;
-import java.util.List;
 
 public interface CommandParserStrategy {
 
     String getStrategyName();
 
-    List<DriverCommand> parse(String rawCommand) throws IOException;
+    DriverCommand parse(String rawCommand, String newCommandName) throws IOException;
 }

--- a/src/main/java/edu/kis/powp/jobs2d/command/parser/jackson/JacksonParserFactory.java
+++ b/src/main/java/edu/kis/powp/jobs2d/command/parser/jackson/JacksonParserFactory.java
@@ -1,0 +1,41 @@
+package edu.kis.powp.jobs2d.command.parser.jackson;
+
+import edu.kis.powp.jobs2d.command.parser.CommandParserFactory;
+import edu.kis.powp.jobs2d.command.parser.CommandParserStrategy;
+import edu.kis.powp.jobs2d.command.parser.jackson.strategies.CsvCommandParser;
+import edu.kis.powp.jobs2d.command.parser.jackson.strategies.JsonCommandParser;
+import edu.kis.powp.jobs2d.command.parser.jackson.strategies.XmlCommandParser;
+
+import java.util.*;
+
+public class JacksonParserFactory implements CommandParserFactory {
+
+	private final Map<String, CommandParserStrategy> availableStrategies;
+
+	public JacksonParserFactory() {
+		availableStrategies = new HashMap<>();
+
+		CommandParserStrategy json = new JsonCommandParser();
+		CommandParserStrategy xml = new XmlCommandParser();
+		CommandParserStrategy csv = new CsvCommandParser();
+
+		availableStrategies.put(json.getStrategyName(), json);
+		availableStrategies.put(xml.getStrategyName(), xml);
+		availableStrategies.put(csv.getStrategyName(), csv);
+	}
+
+
+	@Override
+	public Collection<String> getAvailableParsers() {
+		return availableStrategies.keySet();
+	}
+
+	@Override
+	public CommandParserStrategy getParser(String parserName) {
+		if (!getAvailableParsers().contains(parserName)) {
+			return null;
+		}
+
+		return availableStrategies.getOrDefault(parserName, null);
+	}
+}

--- a/src/main/java/edu/kis/powp/jobs2d/command/parser/jackson/JacksonParserFactory.java
+++ b/src/main/java/edu/kis/powp/jobs2d/command/parser/jackson/JacksonParserFactory.java
@@ -10,32 +10,32 @@ import java.util.*;
 
 public class JacksonParserFactory implements CommandParserFactory {
 
-	private final Map<String, CommandParserStrategy> availableStrategies;
+    private final Map<String, CommandParserStrategy> availableStrategies;
 
-	public JacksonParserFactory() {
-		availableStrategies = new HashMap<>();
+    public JacksonParserFactory() {
+        availableStrategies = new HashMap<>();
 
-		CommandParserStrategy json = new JsonCommandParser();
-		CommandParserStrategy xml = new XmlCommandParser();
-		CommandParserStrategy csv = new CsvCommandParser();
+        CommandParserStrategy json = new JsonCommandParser();
+        CommandParserStrategy xml = new XmlCommandParser();
+        CommandParserStrategy csv = new CsvCommandParser();
 
-		availableStrategies.put(json.getStrategyName(), json);
-		availableStrategies.put(xml.getStrategyName(), xml);
-		availableStrategies.put(csv.getStrategyName(), csv);
-	}
+        availableStrategies.put(json.getStrategyName(), json);
+        availableStrategies.put(xml.getStrategyName(), xml);
+        availableStrategies.put(csv.getStrategyName(), csv);
+    }
 
 
-	@Override
-	public Collection<String> getAvailableParsers() {
-		return availableStrategies.keySet();
-	}
+    @Override
+    public Collection<String> getAvailableParsers() {
+        return availableStrategies.keySet();
+    }
 
-	@Override
-	public CommandParserStrategy getParser(String parserName) {
-		if (!getAvailableParsers().contains(parserName)) {
-			return null;
-		}
+    @Override
+    public CommandParserStrategy getParser(String parserName) {
+        if (!getAvailableParsers().contains(parserName)) {
+            return null;
+        }
 
-		return availableStrategies.getOrDefault(parserName, null);
-	}
+        return availableStrategies.getOrDefault(parserName, null);
+    }
 }

--- a/src/main/java/edu/kis/powp/jobs2d/command/parser/jackson/JacksonParserFactory.java
+++ b/src/main/java/edu/kis/powp/jobs2d/command/parser/jackson/JacksonParserFactory.java
@@ -6,7 +6,9 @@ import edu.kis.powp.jobs2d.command.parser.jackson.strategies.CsvCommandParser;
 import edu.kis.powp.jobs2d.command.parser.jackson.strategies.JsonCommandParser;
 import edu.kis.powp.jobs2d.command.parser.jackson.strategies.XmlCommandParser;
 
-import java.util.*;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
 
 public class JacksonParserFactory implements CommandParserFactory {
 

--- a/src/main/java/edu/kis/powp/jobs2d/command/parser/jackson/strategies/AbstractJacksonCommandParser.java
+++ b/src/main/java/edu/kis/powp/jobs2d/command/parser/jackson/strategies/AbstractJacksonCommandParser.java
@@ -1,0 +1,68 @@
+package edu.kis.powp.jobs2d.command.parser.jackson.strategies;
+
+import edu.kis.powp.jobs2d.command.CompoundCommand;
+import edu.kis.powp.jobs2d.command.DriverCommand;
+import edu.kis.powp.jobs2d.command.OperateToCommand;
+import edu.kis.powp.jobs2d.command.SetPositionCommand;
+import edu.kis.powp.jobs2d.command.parser.CommandParserStrategy;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public abstract class AbstractJacksonCommandParser implements CommandParserStrategy {
+
+	public abstract List<Map<String, Object>> getParsedRaw(String rawCommand) throws IOException;
+
+	@Override
+	public List<DriverCommand> parse(String rawCommand) throws IOException {
+
+		List<Map<String, Object>> rawCommands = getParsedRaw(rawCommand);
+
+		List<DriverCommand> commands = new ArrayList<>();
+
+		for (Map<String, Object> cmd : rawCommands) {
+			if (!cmd.containsKey("name")) {
+				throw new IOException("No command name is present");
+			}
+			String rawCommandName = (String) cmd.get("name");
+
+			switch (rawCommandName) {
+				case "OperateToCommand": {
+					Integer[] props =  parsePrimitiveCommandProps(cmd, rawCommandName);
+					commands.add(new OperateToCommand(props[0], props[1]));
+
+					break;
+				}
+				case "SetPositionCommand": {
+					Integer[] props =  parsePrimitiveCommandProps(cmd, rawCommandName);
+					commands.add(new SetPositionCommand(props[0], props[1]));
+
+					break;
+				}
+				default:
+					throw new IOException("Unsupported command: " + rawCommandName);
+			}
+		}
+
+		return commands;
+	}
+
+	private Integer[] parsePrimitiveCommandProps(Map<String, Object> props, String rawCommandName) throws IOException {
+		int x;
+		int y;
+		if (props.containsKey("x")) {
+			x = Integer.parseInt(props.get("x").toString());
+		} else {
+			throw new IOException("No x property for command " + rawCommandName);
+		}
+		if (props.containsKey("y")) {
+			y = Integer.parseInt(props.get("y").toString());
+		} else {
+			throw new IOException("No y property for command " + rawCommandName);
+		}
+
+		return new Integer[] {x, y};
+	}
+}

--- a/src/main/java/edu/kis/powp/jobs2d/command/parser/jackson/strategies/AbstractJacksonCommandParser.java
+++ b/src/main/java/edu/kis/powp/jobs2d/command/parser/jackson/strategies/AbstractJacksonCommandParser.java
@@ -13,56 +13,56 @@ import java.util.Map;
 
 public abstract class AbstractJacksonCommandParser implements CommandParserStrategy {
 
-	public abstract List<Map<String, Object>> getParsedRaw(String rawCommand) throws IOException;
+    public abstract List<Map<String, Object>> getParsedRaw(String rawCommand) throws IOException;
 
-	@Override
-	public List<DriverCommand> parse(String rawCommand) throws IOException {
+    @Override
+    public List<DriverCommand> parse(String rawCommand) throws IOException {
 
-		List<Map<String, Object>> rawCommands = getParsedRaw(rawCommand);
+        List<Map<String, Object>> rawCommands = getParsedRaw(rawCommand);
 
-		List<DriverCommand> commands = new ArrayList<>();
+        List<DriverCommand> commands = new ArrayList<>();
 
-		for (Map<String, Object> cmd : rawCommands) {
-			if (!cmd.containsKey("name")) {
-				throw new IOException("No command name is present");
-			}
-			String rawCommandName = (String) cmd.get("name");
+        for (Map<String, Object> cmd : rawCommands) {
+            if (!cmd.containsKey("name")) {
+                throw new IOException("No command name is present");
+            }
+            String rawCommandName = (String) cmd.get("name");
 
-			switch (rawCommandName) {
-				case "OperateToCommand": {
-					Integer[] props =  parsePrimitiveCommandProps(cmd, rawCommandName);
-					commands.add(new OperateToCommand(props[0], props[1]));
+            switch (rawCommandName) {
+                case "OperateToCommand": {
+                    Integer[] props = parsePrimitiveCommandProps(cmd, rawCommandName);
+                    commands.add(new OperateToCommand(props[0], props[1]));
 
-					break;
-				}
-				case "SetPositionCommand": {
-					Integer[] props =  parsePrimitiveCommandProps(cmd, rawCommandName);
-					commands.add(new SetPositionCommand(props[0], props[1]));
+                    break;
+                }
+                case "SetPositionCommand": {
+                    Integer[] props = parsePrimitiveCommandProps(cmd, rawCommandName);
+                    commands.add(new SetPositionCommand(props[0], props[1]));
 
-					break;
-				}
-				default:
-					throw new IOException("Unsupported command: " + rawCommandName);
-			}
-		}
+                    break;
+                }
+                default:
+                    throw new IOException("Unsupported command: " + rawCommandName);
+            }
+        }
 
-		return commands;
-	}
+        return commands;
+    }
 
-	private Integer[] parsePrimitiveCommandProps(Map<String, Object> props, String rawCommandName) throws IOException {
-		int x;
-		int y;
-		if (props.containsKey("x")) {
-			x = Integer.parseInt(props.get("x").toString());
-		} else {
-			throw new IOException("No x property for command " + rawCommandName);
-		}
-		if (props.containsKey("y")) {
-			y = Integer.parseInt(props.get("y").toString());
-		} else {
-			throw new IOException("No y property for command " + rawCommandName);
-		}
+    private Integer[] parsePrimitiveCommandProps(Map<String, Object> props, String rawCommandName) throws IOException {
+        int x;
+        int y;
+        if (props.containsKey("x")) {
+            x = Integer.parseInt(props.get("x").toString());
+        } else {
+            throw new IOException("No x property for command " + rawCommandName);
+        }
+        if (props.containsKey("y")) {
+            y = Integer.parseInt(props.get("y").toString());
+        } else {
+            throw new IOException("No y property for command " + rawCommandName);
+        }
 
-		return new Integer[] {x, y};
-	}
+        return new Integer[]{x, y};
+    }
 }

--- a/src/main/java/edu/kis/powp/jobs2d/command/parser/jackson/strategies/AbstractJacksonCommandParser.java
+++ b/src/main/java/edu/kis/powp/jobs2d/command/parser/jackson/strategies/AbstractJacksonCommandParser.java
@@ -16,7 +16,7 @@ public abstract class AbstractJacksonCommandParser implements CommandParserStrat
     public abstract List<Map<String, Object>> getParsedRaw(String rawCommand) throws IOException;
 
     @Override
-    public List<DriverCommand> parse(String rawCommand) throws IOException {
+    public DriverCommand parse(String rawCommand, String newCommandName) throws IOException {
 
         List<Map<String, Object>> rawCommands = getParsedRaw(rawCommand);
 
@@ -46,7 +46,7 @@ public abstract class AbstractJacksonCommandParser implements CommandParserStrat
             }
         }
 
-        return commands;
+        return new CompoundCommand(commands, newCommandName);
     }
 
     private Integer[] parsePrimitiveCommandProps(Map<String, Object> props, String rawCommandName) throws IOException {

--- a/src/main/java/edu/kis/powp/jobs2d/command/parser/jackson/strategies/CsvCommandParser.java
+++ b/src/main/java/edu/kis/powp/jobs2d/command/parser/jackson/strategies/CsvCommandParser.java
@@ -16,25 +16,25 @@ import java.util.Map;
 
 public class CsvCommandParser extends AbstractJacksonCommandParser {
 
-	private CsvMapper csvMapper = new CsvMapper();
-	private CsvSchema schema = CsvSchema.builder()
-			.addColumn("name")
-			.addColumn("x")
-			.addColumn("y")
-			.build()
-			.withHeader();
+    private CsvMapper csvMapper = new CsvMapper();
+    private CsvSchema schema = CsvSchema.builder()
+            .addColumn("name")
+            .addColumn("x")
+            .addColumn("y")
+            .build()
+            .withHeader();
 
-	@Override
-	public List<Map<String, Object>> getParsedRaw(String rawCommand) throws IOException {
-		CsvSchema csvSchema = CsvSchema.emptySchema().withHeader();
-		ObjectReader mapper = new CsvMapper().readerFor(Map.class).with(csvSchema);
-		MappingIterator<Map<String, Object>> iterator = mapper.readValues(rawCommand);
+    @Override
+    public List<Map<String, Object>> getParsedRaw(String rawCommand) throws IOException {
+        CsvSchema csvSchema = CsvSchema.emptySchema().withHeader();
+        ObjectReader mapper = new CsvMapper().readerFor(Map.class).with(csvSchema);
+        MappingIterator<Map<String, Object>> iterator = mapper.readValues(rawCommand);
 
-		return iterator.readAll();
-	}
+        return iterator.readAll();
+    }
 
-	@Override
-	public String getStrategyName() {
-		return "CSV";
-	}
+    @Override
+    public String getStrategyName() {
+        return "CSV";
+    }
 }

--- a/src/main/java/edu/kis/powp/jobs2d/command/parser/jackson/strategies/CsvCommandParser.java
+++ b/src/main/java/edu/kis/powp/jobs2d/command/parser/jackson/strategies/CsvCommandParser.java
@@ -1,14 +1,9 @@
 package edu.kis.powp.jobs2d.command.parser.jackson.strategies;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.MappingIterator;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.dataformat.csv.CsvMapper;
 import com.fasterxml.jackson.dataformat.csv.CsvSchema;
-import edu.kis.powp.jobs2d.command.DriverCommand;
-import edu.kis.powp.jobs2d.command.parser.CommandParserStrategy;
-import edu.kis.powp.jobs2d.command.parser.jackson.JacksonParserFactory;
 
 import java.io.IOException;
 import java.util.List;

--- a/src/main/java/edu/kis/powp/jobs2d/command/parser/jackson/strategies/CsvCommandParser.java
+++ b/src/main/java/edu/kis/powp/jobs2d/command/parser/jackson/strategies/CsvCommandParser.java
@@ -1,0 +1,40 @@
+package edu.kis.powp.jobs2d.command.parser.jackson.strategies;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.MappingIterator;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+import com.fasterxml.jackson.dataformat.csv.CsvMapper;
+import com.fasterxml.jackson.dataformat.csv.CsvSchema;
+import edu.kis.powp.jobs2d.command.DriverCommand;
+import edu.kis.powp.jobs2d.command.parser.CommandParserStrategy;
+import edu.kis.powp.jobs2d.command.parser.jackson.JacksonParserFactory;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+public class CsvCommandParser extends AbstractJacksonCommandParser {
+
+	private CsvMapper csvMapper = new CsvMapper();
+	private CsvSchema schema = CsvSchema.builder()
+			.addColumn("name")
+			.addColumn("x")
+			.addColumn("y")
+			.build()
+			.withHeader();
+
+	@Override
+	public List<Map<String, Object>> getParsedRaw(String rawCommand) throws IOException {
+		CsvSchema csvSchema = CsvSchema.emptySchema().withHeader();
+		ObjectReader mapper = new CsvMapper().readerFor(Map.class).with(csvSchema);
+		MappingIterator<Map<String, Object>> iterator = mapper.readValues(rawCommand);
+
+		return iterator.readAll();
+	}
+
+	@Override
+	public String getStrategyName() {
+		return "CSV";
+	}
+}

--- a/src/main/java/edu/kis/powp/jobs2d/command/parser/jackson/strategies/JsonCommandParser.java
+++ b/src/main/java/edu/kis/powp/jobs2d/command/parser/jackson/strategies/JsonCommandParser.java
@@ -3,14 +3,7 @@ package edu.kis.powp.jobs2d.command.parser.jackson.strategies;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import edu.kis.powp.jobs2d.command.CompoundCommand;
-import edu.kis.powp.jobs2d.command.DriverCommand;
-import edu.kis.powp.jobs2d.command.OperateToCommand;
-import edu.kis.powp.jobs2d.command.SetPositionCommand;
-import edu.kis.powp.jobs2d.command.parser.CommandParserStrategy;
 
-import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 

--- a/src/main/java/edu/kis/powp/jobs2d/command/parser/jackson/strategies/JsonCommandParser.java
+++ b/src/main/java/edu/kis/powp/jobs2d/command/parser/jackson/strategies/JsonCommandParser.java
@@ -15,19 +15,19 @@ import java.util.List;
 import java.util.Map;
 
 public class JsonCommandParser extends AbstractJacksonCommandParser {
-	private final ObjectMapper mapper = new ObjectMapper();
+    private final ObjectMapper mapper = new ObjectMapper();
 
-	@Override
-	public List<Map<String, Object>> getParsedRaw(String rawCommand) throws JsonProcessingException {
-		return mapper.readValue(
-				rawCommand,
-				new TypeReference<List<Map<String, Object>>>() {
-				}
-		);
-	}
+    @Override
+    public List<Map<String, Object>> getParsedRaw(String rawCommand) throws JsonProcessingException {
+        return mapper.readValue(
+                rawCommand,
+                new TypeReference<List<Map<String, Object>>>() {
+                }
+        );
+    }
 
-	@Override
-	public String getStrategyName() {
-		return "JSON";
-	}
+    @Override
+    public String getStrategyName() {
+        return "JSON";
+    }
 }

--- a/src/main/java/edu/kis/powp/jobs2d/command/parser/jackson/strategies/JsonCommandParser.java
+++ b/src/main/java/edu/kis/powp/jobs2d/command/parser/jackson/strategies/JsonCommandParser.java
@@ -1,0 +1,33 @@
+package edu.kis.powp.jobs2d.command.parser.jackson.strategies;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.kis.powp.jobs2d.command.CompoundCommand;
+import edu.kis.powp.jobs2d.command.DriverCommand;
+import edu.kis.powp.jobs2d.command.OperateToCommand;
+import edu.kis.powp.jobs2d.command.SetPositionCommand;
+import edu.kis.powp.jobs2d.command.parser.CommandParserStrategy;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class JsonCommandParser extends AbstractJacksonCommandParser {
+	private final ObjectMapper mapper = new ObjectMapper();
+
+	@Override
+	public List<Map<String, Object>> getParsedRaw(String rawCommand) throws JsonProcessingException {
+		return mapper.readValue(
+				rawCommand,
+				new TypeReference<List<Map<String, Object>>>() {
+				}
+		);
+	}
+
+	@Override
+	public String getStrategyName() {
+		return "JSON";
+	}
+}

--- a/src/main/java/edu/kis/powp/jobs2d/command/parser/jackson/strategies/XmlCommandParser.java
+++ b/src/main/java/edu/kis/powp/jobs2d/command/parser/jackson/strategies/XmlCommandParser.java
@@ -1,0 +1,28 @@
+package edu.kis.powp.jobs2d.command.parser.jackson.strategies;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+
+import java.util.List;
+import java.util.Map;
+
+public class XmlCommandParser extends AbstractJacksonCommandParser {
+	private final ObjectMapper mapper = new XmlMapper();
+
+	@Override
+	public List<Map<String, Object>> getParsedRaw(String rawCommand) throws JsonProcessingException {
+		return mapper.readValue(
+				rawCommand,
+				new TypeReference<List<Map<String, Object>>>() {
+				}
+		);
+	}
+
+	@Override
+	public String getStrategyName() {
+		return "XML";
+	}
+
+}

--- a/src/main/java/edu/kis/powp/jobs2d/command/parser/jackson/strategies/XmlCommandParser.java
+++ b/src/main/java/edu/kis/powp/jobs2d/command/parser/jackson/strategies/XmlCommandParser.java
@@ -9,20 +9,20 @@ import java.util.List;
 import java.util.Map;
 
 public class XmlCommandParser extends AbstractJacksonCommandParser {
-	private final ObjectMapper mapper = new XmlMapper();
+    private final ObjectMapper mapper = new XmlMapper();
 
-	@Override
-	public List<Map<String, Object>> getParsedRaw(String rawCommand) throws JsonProcessingException {
-		return mapper.readValue(
-				rawCommand,
-				new TypeReference<List<Map<String, Object>>>() {
-				}
-		);
-	}
+    @Override
+    public List<Map<String, Object>> getParsedRaw(String rawCommand) throws JsonProcessingException {
+        return mapper.readValue(
+                rawCommand,
+                new TypeReference<List<Map<String, Object>>>() {
+                }
+        );
+    }
 
-	@Override
-	public String getStrategyName() {
-		return "XML";
-	}
+    @Override
+    public String getStrategyName() {
+        return "XML";
+    }
 
 }

--- a/src/test/java/edu/kis/powp/jobs2d/TestJobs2dApp.java
+++ b/src/test/java/edu/kis/powp/jobs2d/TestJobs2dApp.java
@@ -16,6 +16,7 @@ import edu.kis.powp.jobs2d.canvas.RectangleCanvas;
 import edu.kis.powp.jobs2d.canvas.RectangleCanvas.Format;
 import edu.kis.powp.jobs2d.command.gui.CommandManagerWindow;
 import edu.kis.powp.jobs2d.command.gui.CommandManagerWindowCommandChangeObserver;
+import edu.kis.powp.jobs2d.command.parser.jackson.JacksonParserFactory;
 import edu.kis.powp.jobs2d.drivers.DriverComposite;
 import edu.kis.powp.jobs2d.drivers.ImprovedLoggerDriver;
 import edu.kis.powp.jobs2d.drivers.adapter.LineDriverAdapter;
@@ -102,7 +103,7 @@ public class TestJobs2dApp {
     }
 
     private static void setupWindows(Application application) {
-        CommandManagerWindow commandManager = new CommandManagerWindow(CommandsFeature.getDriverCommandManager());
+        CommandManagerWindow commandManager = new CommandManagerWindow(CommandsFeature.getDriverCommandManager(), new JacksonParserFactory());
         application.addWindowComponent("Command Manager", commandManager);
 
         CommandManagerWindowCommandChangeObserver windowObserver = new CommandManagerWindowCommandChangeObserver(commandManager);

--- a/src/test/java/edu/kis/powp/jobs2d/TestJobs2dApp.java
+++ b/src/test/java/edu/kis/powp/jobs2d/TestJobs2dApp.java
@@ -1,15 +1,8 @@
 package edu.kis.powp.jobs2d;
 
-import java.awt.EventQueue;
-import java.awt.event.ActionEvent;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import edu.kis.legacy.drawer.panel.DrawPanelController;
 import edu.kis.legacy.drawer.shape.LineFactory;
 import edu.kis.powp.appbase.Application;
-import edu.kis.powp.jobs2d.canvas.Canvas;
 import edu.kis.powp.jobs2d.canvas.EllipseCanvas;
 import edu.kis.powp.jobs2d.canvas.ICanvas;
 import edu.kis.powp.jobs2d.canvas.RectangleCanvas;
@@ -24,15 +17,12 @@ import edu.kis.powp.jobs2d.drivers.adapter.transformation.TransformationFlip;
 import edu.kis.powp.jobs2d.drivers.adapter.transformation.TransformationFlipAxis;
 import edu.kis.powp.jobs2d.drivers.adapter.transformation.TransformationScale;
 import edu.kis.powp.jobs2d.events.*;
-import edu.kis.powp.jobs2d.features.CommandsFeature;
-import edu.kis.powp.jobs2d.features.DrawerFeature;
-import edu.kis.powp.jobs2d.features.DriverFeature;
-import edu.kis.powp.jobs2d.features.MouseClickDrawFeature;
-import edu.kis.powp.jobs2d.features.CanvasFeature;
 import edu.kis.powp.jobs2d.features.*;
+
 import java.awt.*;
 import java.awt.event.ActionEvent;
-import java.sql.Driver;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -71,7 +61,7 @@ public class TestJobs2dApp {
      */
     private static void setupDrivers(Application application) {
         DriverComposite driverComposite = new DriverComposite();    // addidtion to composite
-  
+
         Job2dDriver loggerDriver = new ImprovedLoggerDriver(false);
         DriverFeature.addDriver("Logger driver", loggerDriver);
 
@@ -84,7 +74,7 @@ public class TestJobs2dApp {
         DriverFeature.addDriver("Line Simulator", driver);
         DriverFeature.getDriverManager().setCurrentDriver(driver);
         driverComposite.addDriver(driver);  // addidtion to composite
-    
+
         driver = new LineDriverAdapter(drawerController, LineFactory.getSpecialLine(), "special");
         DriverFeature.addDriver("Special line Simulator", driver);
 
@@ -144,7 +134,7 @@ public class TestJobs2dApp {
 
                 CanvasFeature.setCanvases(canvases);
                 CanvasFeature.setupCanvasFeature(app);
-                
+
                 DriverFeature.setupDriverPlugin(app);
                 TransformationFeature.setupTransformationPlugin(app, DriverFeature.getDriverManager());
                 setupTransformations();

--- a/src/test/resources/Csv_Command_Example.csv
+++ b/src/test/resources/Csv_Command_Example.csv
@@ -1,0 +1,6 @@
+name,x,y
+SetPositionCommand,-50,-50
+OperateToCommand,50,-50
+OperateToCommand,50,50
+OperateToCommand,-50,50
+OperateToCommand,-50,-50

--- a/src/test/resources/Json_Command_Example.json
+++ b/src/test/resources/Json_Command_Example.json
@@ -1,0 +1,27 @@
+[
+  {
+    "name": "SetPositionCommand",
+    "x": -50,
+    "y": -50
+  },
+  {
+    "name": "OperateToCommand",
+    "x": 50,
+    "y": -50
+  },
+  {
+    "name": "OperateToCommand",
+    "x": 50,
+    "y": 50
+  },
+  {
+    "name": "OperateToCommand",
+    "x": -50,
+    "y": 50
+  },
+  {
+    "name": "OperateToCommand",
+    "x": -50,
+    "y": -50
+  }
+]

--- a/src/test/resources/Xml_Command_Example.xml
+++ b/src/test/resources/Xml_Command_Example.xml
@@ -1,0 +1,7 @@
+<commands>
+    <command name="SetPositionCommand" x="-50" y="-50"/>
+    <command name="OperateToCommand" x="50" y="-50"/>
+    <command name="OperateToCommand" x="50" y="50"/>
+    <command name="OperateToCommand" x="-50" y="50"/>
+    <command name="OperateToCommand" x="-50" y="-50"/>
+</commands>


### PR DESCRIPTION
Changes require adding Jackson dependency (with two additional modules) to allow parsing JSON/XML/CSV.

Parsing commands is exposed via `CommandParserStrategy`, which allows parsing `String` into `List<DriverCommand>`. Additionally it provides strategy name, for identification using factories.

Accessing command parsers is exposed via `CommandParserFactory`, which allows to get list of available command parser names, and retrieve command parser via its name.

The bulk of parsing logic for JSON/XML/CSV is implemented in `AbstractJacksonCommandParser`, which accepts pre-parsed object (`List<Map<String, Object>>`) and parses it into final list of commands. For concrete format classes (`JsonCommandParser`/`XmlCommandParser`/`CsvCommandParser`), only pre-parsing (and providing strategy name) is necessary - using corresponding Jackson modules.

For end-user, parsing is provided inside `CommandManagerWindow`, where additional form elements are placed:
- text input for name of new command,
- text area for serialized commands to import,
- select box for choosing parser strategy,
- submit button, which sets current command to parsed command.
`JacksonParserFactory` is injected into `CommandManagerWindow` constructor (via `CommandParserFactory` interface).

Examples of serialized commands are provided in `src/test/resources/` in their respective files.